### PR TITLE
fix MessageMediaWebPage

### DIFF
--- a/userbot/assistant/bot_pms.py
+++ b/userbot/assistant/bot_pms.py
@@ -172,6 +172,14 @@ async def bot_pms(event):  # sourcery no-metrics
         if user_id is not None:
             try:
                 if event.media:
+                    if event.media.webpage:
+                        msg = await event.client.send_message(
+                            user_id, event.text, reply_to=reply_msg
+                            )
+                    else:
+                        msg = await event.client.send_file(
+                            user_id, event.media, caption=event.text, reply_to=reply_msg
+                            )
                     msg = await event.client.send_file(
                         user_id, event.media, caption=event.text, reply_to=reply_msg
                     )


### PR DESCRIPTION
Error when sending a url with webpage preview as True:
Cannot use <telethon.tl.types.MessageMediaWebPage object at 0x7f1656787760> as fille
